### PR TITLE
Implement message reply sbt

### DIFF
--- a/cogs/spongebobText.py
+++ b/cogs/spongebobText.py
@@ -1,31 +1,31 @@
 import time
+from typing import List
 
-from discord.ext.commands import command
-from discord.ext.commands import Cog
+from discord.ext.commands import Cog, command
 
 
-def removeSpace(list):
-    newList = [i for i in list if i != ' ']
+def removeSpace(lst: List[str]) -> List[str]:
+    newList = [i for i in lst if i != ' ']
     return newList
 
 
-def getSpaceIndex(list):
-    spaces = [i for i, letter in enumerate(list) if letter == ' ']
+def getSpaceIndex(lst: List[str]) -> List[int]:
+    spaces = [i for i, letter in enumerate(lst) if letter == ' ']
     return spaces
 
 
-def addSpacesBack(list, spaces):
-    for i in range(0, len(list) + len(spaces)):
+def addSpacesBack(lst: List[str], spaces: List[int]) -> List[str]:
+    for i in range(0, len(lst) + len(spaces)):
         if i in spaces:
-            list.insert(i, ' ')
-    return list
+            lst.insert(i, ' ')
+    return lst
 
 
-def camelify(list):
-    for i in range(0, len(list)):
+def camelify(lst: List[str]) -> List[str]:
+    for i in range(0, len(lst)):
         if i % 2 == 0:
-            list[i] = list[i].upper()
-    return list
+            lst[i] = lst[i].upper()
+    return lst
 
 
 class SpongebobText(Cog):
@@ -38,17 +38,33 @@ class SpongebobText(Cog):
         brief='Output text in the Spongebob meme format'
     )
     async def sbt(self, ctx):
-        rawMessage = ctx.message.content
-        message = rawMessage.replace('.sbt ', '')
-        lower = message.lower()
-        letters = list(lower)
+        def get_sbt_text(message: str) -> str:
+            lower = message.lower()
+            letters = list(lower)
 
-        spaces = getSpaceIndex(letters)
-        spacesRemovedLetters = removeSpace(letters)
-        camelifiedLetters = camelify(spacesRemovedLetters)
-        lettersHalf = addSpacesBack(camelifiedLetters, spaces)
+            spaces = getSpaceIndex(letters)
+            spacesRemovedLetters = removeSpace(letters)
+            camelifiedLetters = camelify(spacesRemovedLetters)
+            lettersHalf = addSpacesBack(camelifiedLetters, spaces)
+            return ''.join(lettersHalf)
 
-        sbText = ''.join(lettersHalf)
+        async def sbt_message_reply() -> str:
+            message_obj: discord.Message = await ctx.fetch_message(ctx.message.reference.message_id)
+            return get_sbt_text(message_obj.content)
+
+        async def sbt_text_argument() -> str:
+            rawMessage: str = ctx.message.content
+            message: str = rawMessage.replace('.sbt ', '')
+            return get_sbt_text(message)
+
+        sbText: str = ''
+
+        # If message is a reply, then sbt-ify the replied-to message
+        if ctx.message.reference is not None:
+            sbText = await sbt_message_reply()
+        else: # sbt-ify the text in the message
+            sbText = await sbt_text_argument()
+
         await ctx.send(sbText)
 
         time.sleep(3)


### PR DESCRIPTION
This pull request will close issue #1 

The assumption is that if the command is replying to a message then it takes the replied-to message instead, ignoring whatever comes after `.sbt` (see lines 62-66 in spongebobText.py)

Also I added some typing to function parameter and return values

Changed `list` to `lst` since `list` is a reserved keyword in python